### PR TITLE
Set correct Content-Length after replace

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -228,7 +228,11 @@ func (m Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddy
 			return m.replacer(input, repl) // forward the replacement processing
 		})
 
-		csr.Header().Set("Content-Length", strconv.Itoa(len(replaced)))
+		oldContentLength := csr.Header().Get("Content-Length")
+		if len(oldContentLength) > 0 {
+			csr.Header().Set("Content-Length", strconv.Itoa(len(replaced)))
+		}
+
 		csr.FlushHeaders()
 		if _, err := io.Copy(w, bytes.NewReader(replaced)); err != nil {
 			return fmt.Errorf("error when copying replaced response body: %w", err)

--- a/filter.go
+++ b/filter.go
@@ -217,7 +217,7 @@ func (m Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddy
 	if csr.Overflowed() {
 		return nextErr
 	}
-	csr.FlushHeaders()
+
 	if m.compiledContentTypeRegex.MatchString(csr.Recorder().Result().Header.Get("Content-Type")) {
 		buf := new(bytes.Buffer)
 		repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
@@ -227,10 +227,14 @@ func (m Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddy
 		replaced := m.compiledSearchRegex.ReplaceAllFunc(buf.Bytes(), func(input []byte) []byte {
 			return m.replacer(input, repl) // forward the replacement processing
 		})
+
+		csr.Header().Set("Content-Length", strconv.Itoa(len(replaced)))
+		csr.FlushHeaders()
 		if _, err := io.Copy(w, bytes.NewReader(replaced)); err != nil {
 			return fmt.Errorf("error when copying replaced response body: %w", err)
 		}
 	} else {
+		csr.FlushHeaders()
 		if _, err := io.Copy(w, csr.recorder.Body); err != nil {
 			return fmt.Errorf("error when copying response body: %w", err)
 		}

--- a/test/Caddyfile.6
+++ b/test/Caddyfile.6
@@ -1,0 +1,15 @@
+{
+    debug
+    auto_https off
+    order filter first
+}
+http://localhost:2015 {
+    filter {
+        content_type .*
+        search_pattern <head>
+        replacement "<head><base href=\"https://{http.request.hostport}/foobar />"
+    }
+
+    root * ./test/www/
+    file_server
+}

--- a/test/Caddyfile.6
+++ b/test/Caddyfile.6
@@ -1,7 +1,7 @@
 {
     debug
     auto_https off
-    order filter first
+    order filter after encode
 }
 http://localhost:2015 {
     filter {

--- a/test/run-test
+++ b/test/run-test
@@ -72,3 +72,10 @@ pid="$!"
 retry '/' > output5
 diff output5 test/test-5.ref
 cleanup
+
+echobold 'test case 6'
+$XCADDY run -config test/Caddyfile.6&
+pid="$!"
+retry '/' -i | grep -v Etag | grep -v Last-Modified | grep -v Date > output6
+diff output6 test/test-6.ref
+cleanup

--- a/test/test-6.ref
+++ b/test/test-6.ref
@@ -1,0 +1,14 @@
+HTTP/1.1 200 OK
+Accept-Ranges: bytes
+Content-Length: 158
+Content-Type: text/html; charset=utf-8
+Server: Caddy
+
+<html>
+    <head><base href="https://localhost:2015/foobar />
+        <title>Testing</title>
+    </head>
+    <body>
+        <h1>test</h1>
+    </body>
+</html>

--- a/test/www/index.html
+++ b/test/www/index.html
@@ -1,0 +1,8 @@
+<html>
+    <head>
+        <title>Testing</title>
+    </head>
+    <body>
+        <h1>test</h1>
+    </body>
+</html>


### PR DESCRIPTION
Otherwise I get errors like:

```sh
2021/06/10 15:42:12.244 ERROR   http.log.error  error when copying replaced response body: http: wrote more than the declared Content-Length    {"request": {"remote_addr": "127.0.0.1:38690", "proto": "HTTP/1.1", "method": "GET", "host": "localhost:2015", "uri": "/", "headers": {"User-Agent": ["curl/7.68.0"], "Accept": ["*/*"]}}, "duration": 0.0003476}
```

I looked at https://github.com/echocat/caddy-filter/blob/ce659b810b35d5afd65df90202a290f2a7ae21df/filter.go#L71 for comparison.

First time tinkering with go / caddy. Please point out all flaws. 